### PR TITLE
Add skip bank selection default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2022-01-03
+- Added default value for "skip method selection" config. Fixing missing javascript validations in frontend.
+
 ## [1.0.3] - 2021-12-08
 ### Added
 - Added conflict information with Markup/Paytrail

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "markup/module-paytrail": "*"
   },
   "type": "magento2-module",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "license": "MIT",
   "autoload": {
     "files": [

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -12,6 +12,7 @@
         <is_gateway>0</is_gateway>
         <merchant_id></merchant_id>
         <merchant_secret></merchant_secret>
+        <skip_bank_selection>0</skip_bank_selection>
         <allowspecific>0</allowspecific>
         <can_initialize>1</can_initialize>
         <can_use_checkout>1</can_use_checkout>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-  <module name="Paytrail_PaymentService" setup_version="1.0.3">
+  <module name="Paytrail_PaymentService" setup_version="1.0.4">
     <sequence>
       <module name="Magento_Sales"/>
       <module name="Magento_Payment"/>


### PR DESCRIPTION
Fixes #8 

Adds missing default value for boolean config "skip_bank_selection".
This caused Frontend javascript validations to not trigger when default values were used. Without 0 as a default value javascript would get "null" value for this particular config. Leading to problems in 
view/frontend/web/js/view/payment/method-renderer/paytrail-method.js:121 

null == false comparison will always return false in JavaScript, causing the validations to be skipped.

additional details:
skip_bank_selection config is provided to frontend here: Model/ConfigProvider.php:122
