### PR TITLE
Release111

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2022-04-25
+Fixes:
+- When an already paid order receives a "Fail" callback from API, it is no longer cancelled.
+- "Delayed" status from API no longer causes the order to be cancelled.
+- Invoices are only created for "Ok" api responses. Mitigating an issue where invoices are missing transaction ids.
+
+New features:
+- You can now disable automatic order cancelling, if you are having issues with cancelled orders receiving payments. You can find the setting from Payment method's configuration.
+
 ## [1.1.0] - 2022-02-21
 - Refactor logging to a separate class.
 - Improve error logging beyond Api errors

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -32,6 +32,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     const KEY_REQUEST_LOG = 'request_log';
     const KEY_DEFAULT_ORDER_STATUS = 'order_status';
     const KEY_NOTIFICATION_EMAIL = 'recipient_email';
+    const KEY_CANCEL_ORDER_ON_FAILED_PAYMENT = 'failed_payment_cancel';
 
     /**
      * @var EncryptorInterface
@@ -255,4 +256,12 @@ class Config extends \Magento\Payment\Gateway\Config\Config
         return $this->getValue(self::KEY_NOTIFICATION_EMAIL, $storeId);
     }
 
+    /**
+     * @param int|null $storeId
+     * @return int
+     */
+    public function getCancelOrderOnFailedPayment($storeId = null)
+    {
+        return $this->getValue(self::KEY_CANCEL_ORDER_ON_FAILED_PAYMENT, $storeId);
+    }
 }

--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -332,7 +332,7 @@ class ReceiptDataProvider
             $this->currentOrder->setState(Recurring::ORDER_STATE_CUSTOM_CODE);
             $this->currentOrder->setStatus(Recurring::ORDER_STATUS_CUSTOM_CODE);
             $this->currentOrder->addCommentToStatusHistory(__('Pending payment from Paytrail Payment Service'));
-        } else {
+        } elseif (!($this->currentOrder->getStatus() === 'processing' && $this->currentOrder->getTotalPaid())) {
             $this->currentOrder->setState($orderState)->setStatus($orderState);
             $this->currentOrder->addCommentToStatusHistory(__('Payment has been completed'));
         }

--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -455,7 +455,7 @@ class ReceiptDataProvider
         if ($verifiedPayment && ($status === 'ok' || $status == 'pending' || $status == 'delayed')) {
             return $status;
         } else {
-            $this->currentOrder->addCommentToStatusHistory(__('Order canceled. Failed to complete the payment.'));
+            $this->currentOrder->addCommentToStatusHistory(__('Failed to complete the payment.'));
             $this->orderRepositoryInterface->save($this->currentOrder);
             $this->cancelOrderById($this->currentOrder->getId());
             $this->paytrailHelper->processError(

--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -276,12 +276,13 @@ class ReceiptDataProvider
 
         $this->currentOrderPayment = $this->currentOrder->getPayment();
 
-        /** @var bool $paymentVerified */
+        /** @var string|void $paymentVerified */
         $paymentVerified = $this->verifyPaymentData($params);
-
         $this->processTransaction();
-        $this->processPayment($paymentVerified);
-        $this->processInvoice();
+        if ($paymentVerified === 'ok') {
+            $this->processPayment();
+            $this->processInvoice();
+        }
         $this->processOrder($paymentVerified);
 
         $this->unlockProcessingOrder($this->orderId);
@@ -328,13 +329,13 @@ class ReceiptDataProvider
     {
         $orderState = $this->gatewayConfig->getDefaultOrderStatus();
 
-        if ($paymentVerified === 'pending') {
+        if ($paymentVerified === 'ok') {
+            $this->currentOrder->setState($orderState)->setStatus($orderState);
+            $this->currentOrder->addCommentToStatusHistory(__('Payment has been completed'));
+        } else {
             $this->currentOrder->setState(Recurring::ORDER_STATE_CUSTOM_CODE);
             $this->currentOrder->setStatus(Recurring::ORDER_STATUS_CUSTOM_CODE);
             $this->currentOrder->addCommentToStatusHistory(__('Pending payment from Paytrail Payment Service'));
-        } elseif (!($this->currentOrder->getStatus() === 'processing' && $this->currentOrder->getTotalPaid())) {
-            $this->currentOrder->setState($orderState)->setStatus($orderState);
-            $this->currentOrder->addCommentToStatusHistory(__('Payment has been completed'));
         }
 
         $this->orderRepositoryInterface->save($this->currentOrder);
@@ -375,22 +376,15 @@ class ReceiptDataProvider
         }
     }
 
-    /**
-     * @param bool|string $paymentVerified
-     */
-    protected function processPayment($paymentVerified = false)
+    protected function processPayment()
     {
-        if ($paymentVerified === 'ok') {
+        $transaction = $this->addPaymentTransaction($this->currentOrder, $this->transactionId, $this->getDetails());
 
-            /** @var \Magento\Sales\Model\Order\Payment\Transaction\Builder|null $transaction */
-            $transaction = $this->addPaymentTransaction($this->currentOrder, $this->transactionId, $this->getDetails());
+        $this->currentOrderPayment->addTransactionCommentsToOrder($transaction, '');
+        $this->currentOrderPayment->setLastTransId($this->transactionId);
 
-            $this->currentOrderPayment->addTransactionCommentsToOrder($transaction, '');
-            $this->currentOrderPayment->setLastTransId($this->transactionId);
-
-            if ($this->currentOrder->getStatus() == 'canceled') {
-                $this->notifyCanceledOrder();
-            }
+        if ($this->currentOrder->getStatus() == 'canceled') {
+            $this->notifyCanceledOrder();
         }
     }
 
@@ -458,12 +452,12 @@ class ReceiptDataProvider
         $status = $params['checkout-status'];
         $verifiedPayment = $this->apiData->validateHmac($params, $params['signature']);
 
-        if ($verifiedPayment && ($status === 'ok' || $status == 'pending')) {
+        if ($verifiedPayment && ($status === 'ok' || $status == 'pending' || $status == 'delayed')) {
             return $status;
         } else {
             $this->currentOrder->addCommentToStatusHistory(__('Order canceled. Failed to complete the payment.'));
             $this->orderRepositoryInterface->save($this->currentOrder);
-            $this->orderManagementInterface->cancel($this->currentOrder->getId());
+            $this->cancelOrderById($this->currentOrder->getId());
             $this->paytrailHelper->processError(
                 'Failed to complete the payment. Please try again or contact the customer service.'
             );
@@ -519,15 +513,14 @@ class ReceiptDataProvider
      * @param \Magento\Sales\Model\Order $order
      * @param $transactionId
      * @param array $details
-     * @return \Magento\Sales\Api\Data\TransactionInterface|null
+     * @return \Magento\Sales\Api\Data\TransactionInterface
      */
     protected function addPaymentTransaction(\Magento\Sales\Model\Order $order, $transactionId, array $details = [])
     {
-        /** @var null|\Magento\Sales\Model\Order\Payment\Transaction\Builder $transaction */
-        $transaction = null;
         /** @var \Magento\Framework\DataObject|\Magento\Sales\Api\Data\OrderPaymentInterface |mixed|null $payment */
         $payment = $order->getPayment();
 
+        /** @var \Magento\Sales\Api\Data\TransactionInterface $transaction */
         $transaction = $this->transactionBuilder
             ->setPayment($payment)->setOrder($order)
             ->setTransactionId($transactionId)
@@ -536,5 +529,16 @@ class ReceiptDataProvider
             ->build(Transaction::TYPE_CAPTURE);
         $transaction->setIsClosed(false);
         return $transaction;
+    }
+
+    /**
+     * @param int $orderId
+     * @return void
+     */
+    private function cancelOrderById($orderId): void
+    {
+        if ($this->gatewayConfig->getCancelOrderOnFailedPayment()) {
+            $this->orderManagementInterface->cancel($orderId);
+        }
     }
 }

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -85,6 +85,16 @@
                     <label>Generate Finnish reference number for orders</label>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+                <field id="failed_payment_cancel" translate="label" type="select" sortOrder="80" showInDefault="1" showInWebsite="0"
+                       showInStore="0" canRestore="1">
+                    <label>Automatically cancel orders if the first response from Paytrail API is a failure</label>
+                    <comment><![CDATA[If you experience errors with cancelled orders receiving payments, please turn this
+                    setting to "NO" position. This means that the orders are kept open until cancelled automatically by
+                    cron or manually by admin. See the cron configuration at Sales -> Sales -> Orders cron setting ->
+                    "Pending Payment Order Lifetime" for setting the maximum time Magento waits for a payment.
+                    Remember that as long as the order is open product stock in the order is locked.]]></comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
                 <group id="paytrail_personalization" translate="label" type="text" sortOrder="90" showInDefault="1"
                        showInWebsite="1" showInStore="1">
                     <label>Payment page personalization</label>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -28,6 +28,7 @@
         <recommended_tax_algorithm>0</recommended_tax_algorithm>
         <logo>https://cdn2.hubspot.net/hubfs/335946/System/paytrail-logo.png</logo>
         <rounding_row_tax_percent>24</rounding_row_tax_percent>
+        <failed_payment_cancel>1</failed_payment_cancel>
         <paytrail_personalization>
           <payment_group_bg>#ebebeb</payment_group_bg>
           <payment_group_text>#323232</payment_group_text>

--- a/i18n/fi_FI.csv
+++ b/i18n/fi_FI.csv
@@ -63,6 +63,11 @@ Discount,Alennus
 Shipping,Toimitus
 "Restore a canceled order","Palauta peruutettu tilaus"
 "Restore order #","Palauta tilaus #"
+Hello,Hei
+"Restore order <a href=""%order_url"">%order_increment</a>","Palauta tilaus #<a href=""%order_url"">%order_increment</a>"
+"The payment for the order %order_increment has been completed while the order was in canceled state.
+        Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock.","Tilaukselle #%order_increment saapui maksu tilauksen peruuttamisen jälkeen
+        Pyydämme teitä tarkastamaan kyseisen tilauksen tilan Magenton administa ja käyttämään 'Restore order' toimintoa"
 "The payment for the order #","Maksu tilaukselle #"
 " has been completed while the order was in canceled state. "," on hyväksytty tilauksen ollessa peruutettu tilassa. "
 "Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock.", "Ole hyvä, ja valitse kyseinen tilaus Magenton hallinnassa ja klikkaa Palauta tilaus. Huomioi varastosaldo."

--- a/view/frontend/email/restore_order_notification.html
+++ b/view/frontend/email/restore_order_notification.html
@@ -1,10 +1,27 @@
 <!--@subject {{trans "Restore a canceled order"}} @-->
+<!-- @vars {
+"var order.increment":"order increment",
+"var order.url":"order adminurl"
+} @-->
 
 {{template config_path="design/email/header_template"}}
 
-<h3>{{trans "Restore order #" + var data.order_id|raw}}</h3>
+<h3>{{trans "Hello"}}</h3>
+<h3>
+    {{trans
+        'Restore order <a href="%order_url">%order_increment</a>'
 
-<p>{{trans "The payment for the order #" + var data.order_id|raw + " has been completed while the order was in canceled state. " +
-    "Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock."}}</p>
+        order_url=$order.url
+        order_increment=$order.increment
+    |raw}}
+</h3>
+<p>
+    {{trans
+        "The payment for the order %order_increment has been completed while the order was in canceled state.
+        Please navigate to your Magento orders, select the order in question, and click restore order. Note the stock."
+
+        order_increment=$order.increment
+    |raw}}
+</p>
 
 {{template config_path="design/email/footer_template"}}


### PR DESCRIPTION
Release 1.1.1 Changes in a single pull request Contains the following:

- When an already paid order receives a "Fail" callback from API, it is no longer cancelled.
- "Delayed" status from API no longer causes the order to be cancelled.
- Invoices are only created for checkout-status "Ok" api responses. Mitigating an issue where invoices are missing transaction ids.

New features:
- You can now disable automatic order cancelling, if you are having issues with cancelled orders receiving payments. You can find the setting from Payment method's configuration.