### PR TITLE
Hotfix fix missing constant error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+## [1.3.1] - 2022-11-18
+- Fix undefined constant error during failed payment requests
+
 ## [1.3.0] - 2022-10-27
 - Summary: Update contains a lot of smaller code quality fixes as highlighted by upgrade compatibility tools by Magento. 1.3.0 addresses over 20 different minor issues in the module
 - New Feature: Improve logging and exception handling in controllers

--- a/Model/ReceiptDataProvider.php
+++ b/Model/ReceiptDataProvider.php
@@ -22,7 +22,7 @@ use Paytrail\PaymentService\Exceptions\CheckoutException;
 use Paytrail\PaymentService\Gateway\Config\Config;
 use Paytrail\PaymentService\Helper\ApiData;
 use Paytrail\PaymentService\Helper\Data as paytrailHelper;
-use Paytrail\PaymentService\Setup\Recurring;
+use Paytrail\PaymentService\Setup\Patch\Data\InstallPaytrail;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -300,8 +300,8 @@ class ReceiptDataProvider
             $this->currentOrder->setState($orderState)->setStatus($orderState);
             $this->currentOrder->addCommentToStatusHistory(__('Payment has been completed'));
         } else {
-            $this->currentOrder->setState(Recurring::ORDER_STATE_CUSTOM_CODE);
-            $this->currentOrder->setStatus(Recurring::ORDER_STATUS_CUSTOM_CODE);
+            $this->currentOrder->setState(InstallPaytrail::ORDER_STATE_CUSTOM_CODE);
+            $this->currentOrder->setStatus(InstallPaytrail::ORDER_STATUS_CUSTOM_CODE);
             $this->currentOrder->addCommentToStatusHistory(__('Pending payment from Paytrail Payment Service'));
         }
 

--- a/Setup/Patch/Data/InstallPaytrail.php
+++ b/Setup/Patch/Data/InstallPaytrail.php
@@ -8,6 +8,9 @@ use Magento\Sales\Setup\SalesSetupFactory;
 
 class InstallPaytrail implements DataPatchInterface
 {
+    public const ORDER_STATE_CUSTOM_CODE = 'pending_paytrail_state';
+    public const ORDER_STATUS_CUSTOM_CODE = 'pending_paytrail';
+
     /**
      * @var ModuleDataSetupInterface
      */

--- a/Setup/Patch/Data/InstallPaytrail.php
+++ b/Setup/Patch/Data/InstallPaytrail.php
@@ -76,8 +76,8 @@ class InstallPaytrail implements DataPatchInterface
     private function installPaytrailState(): void
     {
         $data = [
-            'status'            => 'pending_paytrail',
-            'state'             => 'pending_paytrail_state',
+            'status'            => self::ORDER_STATUS_CUSTOM_CODE,
+            'state'             => self::ORDER_STATE_CUSTOM_CODE,
             'is_default'        => 1,
             'visible_on_front'  => 1,
         ];

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "markup/module-paytrail": "*"
   },
   "type": "magento2-module",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "autoload": {
     "files": [


### PR DESCRIPTION
Setup upgrade script refactoring left behind two calls to undefined constants during failed payment request.
Redeclare and re-use constant in the setup class 