### PR TITLE
Fix to not get config inside __constructor

### DIFF
--- a/Model/Adapter/Adapter.php
+++ b/Model/Adapter/Adapter.php
@@ -44,8 +44,6 @@ class Adapter
     ) {
         $this->gatewayConfig = $gatewayConfig;
         $this->moduleList = $moduleList;
-        $this->merchantId = $gatewayConfig->getMerchantId();
-        $this->merchantSecret = $gatewayConfig->getMerchantSecret();
     }
 
     /**
@@ -58,8 +56,8 @@ class Adapter
         try {
             if (class_exists('Paytrail\SDK\Client')) {
                 $paytrailClient = new Client(
-                    $this->merchantId,
-                    $this->merchantSecret,
+                    $this->gatewayConfig->getMerchantId(),
+                    $this->gatewayConfig->getMerchantSecret(),
                     'paytrail-for-adobe-commerce-' . $this->getExtensionVersion()
                 );
                 return $paytrailClient;


### PR DESCRIPTION
## Description

Fixes issue with developer mode cart and checkout page:
![image](https://user-images.githubusercontent.com/3079827/225546930-7119df2a-47fb-4c02-b552-df5a69a979c9.png)
