### PR TITLE
Rc v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2024-05-10
+
+- Fix for DI configuration
+
 ## [2.1.1] - 2024-04-25
 
 - New MFTF test cases

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "markup/module-paytrail": "*"
     },
     "type": "magento2-module",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "license": "MIT",
     "autoload": {
         "files": [

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -11,6 +11,12 @@
                 type="Paytrail\PaymentService\Plugin\Model\TaxConfigPlugin" sortOrder="1" disabled="false"/>
     </type>
 
+    <type name="Paytrail\PaymentService\Gateway\Config\Config">
+        <arguments>
+            <argument name="methodCode" xsi:type="const">Paytrail\PaymentService\Gateway\Config\Config::CODE</argument>
+        </arguments>
+    </type>
+
     <virtualType name="PaytrailAdapter" type="Magento\Payment\Model\Method\Adapter">
         <arguments>
             <argument name="code" xsi:type="const">Paytrail\PaymentService\Gateway\Config\Config::CODE</argument>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Paytrail_PaymentService" setup_version="2.1.1">
+    <module name="Paytrail_PaymentService" setup_version="2.1.2">
         <sequence>
             <module name="Magento_Webapi"/>
             <module name="Magento_Sales"/>


### PR DESCRIPTION
This pull request includes changes related to a version update from 2.1.1 to 2.1.2 for the Paytrail PaymentService module in a Magento project. The changes are mainly associated with updating version numbers in various files, adding a fix for DI configuration, and introducing a new type in the DI configuration file.

Version update:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R11): Documented the changes in the new version 2.1.2, including a fix for DI configuration.
* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L32-R32): Updated the version number from 2.1.1 to 2.1.2.
* [`etc/module.xml`](diffhunk://#diff-cfc6d0cac6c218df3440a678610688f93f9628a67a457c49030a50f4e7fc50d5L4-R4): Updated the setup version from 2.1.1 to 2.1.2.

DI configuration fix:

* [`etc/di.xml`](diffhunk://#diff-093a1e43a11122404c853506b7ca4f661e18dd4f6557ec3089cad8ceae34a606R14-R19): Added a new type `Paytrail\PaymentService\Gateway\Config\Config` with methodCode as an argument. This change is part of the DI configuration fix mentioned in the `CHANGELOG.md`.