### PR TITLE
hotfix/composer-dependendencies: fix composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,12 @@
     "require": {
         "php": "^8.0",
         "paytrail/paytrail-php-sdk": ">=2.7.3",
-        "magento/framework": "*",
+        "magento/framework": ">=102.0.0",
         "ext-curl": "*",
         "nesbot/carbon": "^2.57.0"
     },
     "require-dev": {
-        "magento/magento-coding-standard": "*",
-        "phpunit/phpunit": "^9.5",
-        "magento/product-enterprise-edition": "> 2.4.3"
+        "magento/magento-coding-standard": "*"
     },
     "conflict": {
         "markup/module-paytrail": "*"


### PR DESCRIPTION
This pull request includes updates to the `composer.json` file to refine dependency requirements and development dependencies. The most important changes include setting specific version constraints for `magento/framework` and removing unnecessary development dependencies.

Dependency updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R26): Updated `magento/framework` dependency to require version `>=102.0.0` instead of any version.

Development dependency cleanup:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L21-R26): Removed `phpunit/phpunit` and `magento/product-enterprise-edition` from the `require-dev` section.